### PR TITLE
:bento: chore: test用ヘルパーclassの追加

### DIFF
--- a/.github/workflows/unified-check-ci.yml
+++ b/.github/workflows/unified-check-ci.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Check for script or .cs file changes
         id: check_scripts
         run: |
-          if [[ "${{ steps.get_changed_files.outputs.all_changed_files }}" =~ (src/Assets/Scripts/|.*\.cs$) ]]; then
-            echo "script_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "script_changed=false" >> $GITHUB_OUTPUT
-          fi
+          script_changed=false
+          for file in ${{ steps.get_changed_files.outputs.all_changed_files }}; do
+            if [[ "$file" =~ (src/Assets/Scripts/|.*\.cs$) ]]; then
+              script_changed=true
+              break
+            fi
+          done
+          echo "script_changed=$script_changed" >> $GITHUB_OUTPUT
 
   code-check:
     runs-on: ubuntu-latest
@@ -149,7 +152,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request' && hashFiles('output.md') != ''
         with:
-          recreate: true
+          hide_and_recreate: true
           header: "Ready to Merge"
           path: ./output.md
 
@@ -167,7 +170,6 @@ jobs:
       - name: Add Merge Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          recreate: true
           hide_and_recreate: true
           header: "Ready to Merge"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/test_result_convert_md.rb
+++ b/scripts/test_result_convert_md.rb
@@ -71,8 +71,12 @@ total_failed = editmode_results[:failed] + playmode_results[:failed]
 total_skipped = editmode_results[:skipped] + playmode_results[:skipped]
 pass_rate = (total_passed.to_f / total_tests * 100).round(2)
 
+editmode_all_passed = editmode_results[:passed] == editmode_results[:total]
+playmode_all_passed = playmode_results[:passed] == playmode_results[:total]
+all_tests_passed = editmode_all_passed && playmode_all_passed
+
 # Markdown形式のレポートの初期化
-markdown_report = "# Test Results Summary for PR [##{pr_number} - #{pr_title}](#{pr_url})\n\n"
+markdown_report = "### #{all_tests_passed ? '✅' : '❌'} Ready to Merge\n\n #### Test Results Summary for PR [##{pr_number} - #{pr_title}](#{pr_url})\n\n"
 markdown_report << "<details>\n<summary><strong>Pull Request Details</strong></summary>\n\n"
 markdown_report << "#### ##{pr_number} origin/#{pr_base_ref} <- origin/#{pr_head_ref}\n"
 markdown_report << "**Title:** #{pr_title}\n\n"
@@ -80,9 +84,6 @@ markdown_report << "**Description:**\n\n#{pr_body}\n\n"
 markdown_report << "**Created At:** #{pr_created_at}\n"
 markdown_report << "</details>\n\n---\n"
 
-editmode_all_passed = editmode_results[:passed] == editmode_results[:total]
-playmode_all_passed = playmode_results[:passed] == playmode_results[:total]
-all_tests_passed = editmode_all_passed && playmode_all_passed
 
 all_suites_duration = editmode_results[:suites].values.sum { |suite| suite[:duration] } + playmode_results[:suites].values.sum { |suite| suite[:duration] }
 editmode_total_result = "#{editmode_all_passed ? '✅' : '❌'} editmode-results.xml - #{editmode_results[:passed]}/#{editmode_results[:total]} - Passed in #{editmode_results[:suites].values.sum { |suite| suite[:duration] }}s"

--- a/src/Assets/Editor/Tests/Common/ReflectionHelper.cs
+++ b/src/Assets/Editor/Tests/Common/ReflectionHelper.cs
@@ -1,0 +1,110 @@
+#region
+
+using System;
+using System.Reflection;
+
+#endregion
+
+namespace Editor.Tests.Common
+{
+    public static class ReflectionHelper
+    {
+        // 任意のオブジェクトのprivateフィールドの値を設定する汎用メソッド
+        public static void SetPrivateField<T>(object obj, string fieldName, T value)
+        {
+            var field = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null)
+            {
+                throw new ArgumentException($"Field '{fieldName}' not found on type '{obj.GetType().Name}'.");
+            }
+
+            field.SetValue(obj, value);
+        }
+
+        // 任意のオブジェクトのprivateフィールドの値を取得する汎用メソッド
+        public static T GetPrivateField<T>(object obj, string fieldName)
+        {
+            var field = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null)
+            {
+                throw new ArgumentException($"Field '{fieldName}' not found on type '{obj.GetType().Name}'.");
+            }
+
+            return (T)field.GetValue(obj);
+        }
+
+        // 任意のオブジェクトのprivateプロパティの値を設定する汎用メソッド
+        public static void SetPrivateProperty<T>(object obj, string propertyName, T value)
+        {
+            var property = obj.GetType().GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null)
+            {
+                throw new ArgumentException($"Property '{propertyName}' not found on type '{obj.GetType().Name}'.");
+            }
+
+            property.SetValue(obj, value);
+        }
+
+        // 任意のオブジェクトのprivateプロパティの値を取得する汎用メソッド
+        public static T GetPrivateProperty<T>(object obj, string propertyName)
+        {
+            var property = obj.GetType().GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null)
+            {
+                throw new ArgumentException($"Property '{propertyName}' not found on type '{obj.GetType().Name}'.");
+            }
+
+            return (T)property.GetValue(obj);
+        }
+
+        // 任意のオブジェクトのprivateメソッドを呼び出す汎用メソッド
+        public static object InvokePrivateMethod(object obj, string methodName, params object[] parameters)
+        {
+            var method = obj.GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (method == null)
+            {
+                throw new ArgumentException($"Method '{methodName}' not found on type '{obj.GetType().Name}'.");
+            }
+
+            return method.Invoke(obj, parameters);
+        }
+
+        // フィールドまたはプロパティの取得を試みるメソッド
+        public static T GetPrivateFieldOrProperty<T>(object obj, string name)
+        {
+            var field = obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null)
+            {
+                return (T)field.GetValue(obj);
+            }
+
+            var property = obj.GetType().GetProperty(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property != null)
+            {
+                return (T)property.GetValue(obj);
+            }
+
+            throw new ArgumentException($"Field or Property '{name}' not found on type '{obj.GetType().Name}'.");
+        }
+
+        // フィールドまたはプロパティの設定を試みるメソッド
+        public static void SetPrivateFieldOrProperty<T>(object obj, string name, T value)
+        {
+            var field = obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null)
+            {
+                field.SetValue(obj, value);
+                return;
+            }
+
+            var property = obj.GetType().GetProperty(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null)
+            {
+                throw new ArgumentException($"Field or Property '{name}' not found on type '{obj.GetType().Name}'.");
+            }
+
+            property.SetValue(obj, value);
+
+        }
+    }
+}

--- a/src/Assets/Editor/Tests/Common/ReflectionHelper.cs.meta
+++ b/src/Assets/Editor/Tests/Common/ReflectionHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 679773edf709461685934aaf7ec61387
+timeCreated: 1725964149


### PR DESCRIPTION
## Why
テストコードでのリフレクション操作を簡素化し、再利用可能なヘルパーメソッドを提供する ReflectionHelper クラスを追加しました。
テストの実装で必須になる非公開フィールドやプロパティへのアクセス、非公開メソッドの呼び出しを目的としています