### PR TITLE
:green_heart: test: add branch filters to CI workflow

### DIFF
--- a/.github/workflows/unified-check-ci.yml
+++ b/.github/workflows/unified-check-ci.yml
@@ -3,6 +3,11 @@ name: unified-check-ci.yml
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
+      - develop
+      - 'release/*'
+      - dependabot/** # Dependabot PRs
   push:
     paths:
       - 'src/Assets/Scripts/**'


### PR DESCRIPTION
Allow CI to run on PRs for main, develop, release branches, and Dependabot. Adjust triggers for more controlled testing scenarios.