### PR TITLE
:bug: fix: 地面との距離チェックを追加

### DIFF
--- a/src/Assets/Scripts/Feature/View/PlayerView.cs
+++ b/src/Assets/Scripts/Feature/View/PlayerView.cs
@@ -75,7 +75,7 @@ namespace Feature.View
 
         private void OnCollisionEnter(Collision collision)
         {
-            if (collision.gameObject.CompareTag("Ground"))
+            if (collision.gameObject.CompareTag("Ground") && 1f > transform.GetGroundDistance(10f))
             {
                 isGrounded.Value = true;
             }


### PR DESCRIPTION
地面との衝突判定時に、不正な位置での判定を防ぎます。これにより、間違った衝突判定が減少し、プレイヤーの動作が安定します。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プレイヤーの地面判定ロジックを改善し、プレイヤーが地面にいると見なされる条件を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->