### PR TITLE
:bento: chore: ビルドワークフローに権限設定を追加

### DIFF
--- a/.github/workflows/unity_build_on_devops.yml
+++ b/.github/workflows/unity_build_on_devops.yml
@@ -14,6 +14,12 @@ jobs:
     if: >
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/build')
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
GITHUB_TOKENを環境変数に設定し、権限を追加しました。これにより、コメントからのビルドが可能になります。

## やった事
<!-- このプルリクエストにて何をしたのか？ -->

## Related Issue
- close #~~

## 動作確認
<!--  
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->

## レビューしてほしいこと
- [ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報 -->
- 
