### PR TITLE
:recycle: refactor: scriptableObjectのパラメータ自動グループ化を実装

### DIFF
--- a/src/Assets/Editor/Tests/Common/Editor.Tests.Common.asmdef
+++ b/src/Assets/Editor/Tests/Common/Editor.Tests.Common.asmdef
@@ -5,6 +5,7 @@
     "UnityEngine.TestRunner",
     "UnityEditor.TestRunner",
     "VContainer",
+    "Core.Utilities",
     "UniRx"
   ],
   "includePlatforms": [

--- a/src/Assets/Editor/Tests/Model/Editor.Tests.Model.asmdef
+++ b/src/Assets/Editor/Tests/Model/Editor.Tests.Model.asmdef
@@ -8,6 +8,7 @@
     "Feature.Model",
     "Feature.Common.Parameter",
     "Editor.Tests.Common",
+    "Core.Utilities",
     "UniRx"
   ],
   "includePlatforms": [

--- a/src/Assets/Scripts/Core/Utilities/Parameter.meta
+++ b/src/Assets/Scripts/Core/Utilities/Parameter.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d3f46d9daab1463c9f0d9581accb73a2
+timeCreated: 1732621144

--- a/src/Assets/Scripts/Core/Utilities/Parameter/BaseParameter.cs
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/BaseParameter.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Core.Utilities.Parameter
+{
+    public class BaseParameter: ScriptableObject
+    {
+        
+    }
+}

--- a/src/Assets/Scripts/Core/Utilities/Parameter/BaseParameter.cs.meta
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/BaseParameter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3d8c9203507d4777bc9e0909c698c56a
+timeCreated: 1732621157

--- a/src/Assets/Scripts/Core/Utilities/Parameter/SimpleEditor.cs
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/SimpleEditor.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Core.Utilities.Parameter
+{
+#if UNITY_EDITOR
+    [CustomEditor(typeof(BaseParameter), true)]
+    public class SimpleEditor : Editor
+    {
+        private Dictionary<string, List<SerializedProperty>> groupedProperties = new Dictionary<string, List<SerializedProperty>>();
+        private Dictionary<string, bool> foldouts = new Dictionary<string, bool>();
+
+        private void OnEnable()
+        {
+            // プロパティの初期化
+            InitializeProperties();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            // グループごとにプロパティを表示
+            foreach (var group in groupedProperties)
+            {
+                foldouts[group.Key] = EditorGUILayout.BeginFoldoutHeaderGroup(foldouts[group.Key], group.Key);
+                if (foldouts[group.Key])
+                {
+                    foreach (var prop in group.Value)
+                    {
+                        DrawPropertyWithTooltip(prop);
+                    }
+                }
+                EditorGUILayout.EndFoldoutHeaderGroup();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void InitializeProperties()
+        {
+            groupedProperties.Clear();
+            foldouts.Clear();
+
+            var iterator = serializedObject.GetIterator();
+            var enterChildren = true;
+            var currentHeader = "Default";
+            var targetType = target.GetType();
+
+            while (iterator.NextVisible(enterChildren))
+            {
+                enterChildren = false;
+
+                if (iterator.propertyPath == "m_Script")
+                    continue;
+
+                var field = targetType.GetField(iterator.name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (field == null)
+                    continue;
+
+                // Header属性の取得
+                var headerAttr = field.GetCustomAttribute<ToggleGroupAttribute>();
+                if (headerAttr != null)
+                {
+                    currentHeader = headerAttr.GroupName;
+                }
+
+                if (!groupedProperties.ContainsKey(currentHeader))
+                {
+                    groupedProperties[currentHeader] = new List<SerializedProperty>();
+                    foldouts[currentHeader] = true; // デフォルトで開く
+                }
+
+                groupedProperties[currentHeader].Add(iterator.Copy());
+            }
+        }
+
+        private void DrawPropertyWithTooltip(SerializedProperty property)
+        {
+            var field = target.GetType().GetField(property.name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (field == null)
+                return;
+
+            // Tooltip属性の取得
+            var tooltipAttr = field.GetCustomAttribute<TooltipAttribute>();
+            var label = tooltipAttr != null ? tooltipAttr.tooltip : property.displayName;
+
+            EditorGUILayout.PropertyField(property, new GUIContent(label));
+        }
+    }
+#endif
+}

--- a/src/Assets/Scripts/Core/Utilities/Parameter/SimpleEditor.cs.meta
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/SimpleEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f09061e2ab2498d9d99abbd75c56699
+timeCreated: 1732620581

--- a/src/Assets/Scripts/Core/Utilities/Parameter/ToggleGroup.cs
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/ToggleGroup.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Core.Utilities.Parameter
+{
+    public class ToggleGroupAttribute: Attribute
+    {
+        public string GroupName { get; private set; }
+        public ToggleGroupAttribute(string groupName)
+        {
+            GroupName = groupName;
+        }
+    }
+}

--- a/src/Assets/Scripts/Core/Utilities/Parameter/ToggleGroup.cs.meta
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/ToggleGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 70ef0e9ede3341c08e032f9251174418
+timeCreated: 1732621380

--- a/src/Assets/Scripts/Feature/Common/Constants/EnemyParams.cs
+++ b/src/Assets/Scripts/Feature/Common/Constants/EnemyParams.cs
@@ -1,12 +1,13 @@
 #region
 
+using Core.Utilities.Parameter;
 using UnityEngine;
 
 #endregion
 
 namespace Feature.Common.Constants
 {
-    public class EnemyParams : ScriptableObject
+    public class EnemyParams : BaseParameter
     {
         [Tooltip("発見距離")] public float foundDistance = 10f;
 

--- a/src/Assets/Scripts/Feature/Common/Constants/Feature.Common.Constants.asmdef
+++ b/src/Assets/Scripts/Feature/Common/Constants/Feature.Common.Constants.asmdef
@@ -1,3 +1,16 @@
 {
-  "name": "Feature.Common.Constants"
+    "name": "Feature.Common.Constants",
+    "rootNamespace": "",
+    "references": [
+        "GUID:f2d12220e8ba244b0a3bbac6b49b3cbd"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/src/Assets/Scripts/Feature/Common/Parameter/CharacterParams.cs
+++ b/src/Assets/Scripts/Feature/Common/Parameter/CharacterParams.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using Core.Utilities.Parameter;
 using UnityEngine;
 
 #endregion
@@ -8,15 +9,15 @@ using UnityEngine;
 namespace Feature.Common.Parameter
 {
     [CreateAssetMenu(fileName = "CharacterParams.asset", menuName = "CharacterParams", order = 0)]
-    public class CharacterParams : ScriptableObject
+    public class CharacterParams : BaseParameter
     {
-        [Header("BASE")]
+        [ToggleGroup("BASE")]
         public float speed = 5f;
 
         public float jumpPower = 7f;
         
         
-        [Header("Health"),Tooltip("体力")]
+        [ToggleGroup("Health"),Tooltip("体力")]
         public int health = 100;
 
         [Tooltip("ダメージ後の回復")]
@@ -34,7 +35,7 @@ namespace Feature.Common.Parameter
         [Tooltip("スワップ後に回復する量")]
         public uint swappedRecoveryHealthQuantity = 1;
         
-        [Header("攻撃")]
+        [ToggleGroup("攻撃")]
         public int attackPower = 2;
 
         [Tooltip("〇秒以内で連続攻撃")] public float comboTimeWindow = 1f;
@@ -50,7 +51,7 @@ namespace Feature.Common.Parameter
         [Tooltip("最大コンボ後のクールタイム")] public float maxComboCoolTime = 1.0f;
         // スワップ関連
 
-        [Tooltip("スワップの最大継続時間(Milli)"), Space(10),]
+        [ToggleGroup("スワップ"), Tooltip("スワップの最大継続時間(Milli)"), Space(10),]
         public float swapContinueMaxMillis = 4000f;
 
         [Tooltip("スワップ中のTimeScale"), Range(0.01f, 1.0f),]
@@ -93,10 +94,6 @@ namespace Feature.Common.Parameter
         [Tooltip("ボルテージ使用時の攻撃上昇倍率")] public int voltageAttackPowerValue = 2;
 
         [Tooltip("クナイを飛ばしたときのスタミナ消費")] public uint useDaggerUseStamina = 2;
-        
-        //攻撃関連
-        [Tooltip("ボルテージ時の攻撃エフェクト")] public GameObject slashEffect;
-        [Tooltip("非ボルテージ時の攻撃エフェクト")] public GameObject normalSlashEffect;
         
     }
 

--- a/src/Assets/Scripts/Feature/Common/Parameter/DroneParams.cs
+++ b/src/Assets/Scripts/Feature/Common/Parameter/DroneParams.cs
@@ -1,5 +1,6 @@
 #region
 
+using Core.Utilities.Parameter;
 using Feature.Common.Constants;
 using UnityEngine;
 
@@ -12,7 +13,7 @@ namespace Feature.Common.Parameter
     {
         [Tooltip("水平距離でのプレイヤーとの距離の目標")] public float playerKeepDistance = 8f;
 
-        [Header("自爆"), Tooltip("自爆を開始するまでのHPのしきい値"),]
+        [ToggleGroup("自爆"), Tooltip("自爆を開始するまでのHPのしきい値"),]
         public float thresholdHealth = 4f;
 
         [Tooltip("自爆までのカウントダウン時間")] public float selfDestructionCountDownSec = 3f;
@@ -23,9 +24,9 @@ namespace Feature.Common.Parameter
 
         [Tooltip("自爆のダメージ")] public uint explosionDamage = 20;
 
-        [Header("攻撃の種類"), Tooltip("攻撃の種類"),] public DroneAttackType attackType = DroneAttackType.Bullet;
+        [ToggleGroup("攻撃の種類"), Tooltip("攻撃の種類"),] public DroneAttackType attackType = DroneAttackType.Bullet;
 
-        [Header("Bullet"), Tooltip("弾のプレハブ"),] public GameObject bulletPrefab;
+        [ToggleGroup("Bullet"), Tooltip("弾のプレハブ"),] public GameObject bulletPrefab;
 
         [Tooltip("弾の速度")] public float bulletSpeed = 4f;
 
@@ -33,7 +34,7 @@ namespace Feature.Common.Parameter
 
         [Tooltip("弾の発射後の待機時間")] public float shootIntervalSec = 1f;
 
-        [Header("Ray"), Tooltip("ビームのダメージ"),] public uint rayDamage = 10;
+        [ToggleGroup("Ray"), Tooltip("ビームのダメージ"),] public uint rayDamage = 10;
 
         [Tooltip("ビームの射程")] public float rayRange = 7f;
 

--- a/src/Assets/Scripts/Feature/Common/Parameter/Feature.Common.Parameter.asmdef
+++ b/src/Assets/Scripts/Feature/Common/Parameter/Feature.Common.Parameter.asmdef
@@ -3,7 +3,8 @@
   "rootNamespace": "",
   "references": [
     "GUID:db9310a783d9f406199eff722e946dc5",
-    "GUID:37c78d5c87a084f1b83b0346eddbbaa6"
+    "GUID:37c78d5c87a084f1b83b0346eddbbaa6",
+    "GUID:f2d12220e8ba244b0a3bbac6b49b3cbd"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/src/Assets/Scripts/Feature/Common/Parameter/SimpleEnemy1Params.cs
+++ b/src/Assets/Scripts/Feature/Common/Parameter/SimpleEnemy1Params.cs
@@ -10,14 +10,14 @@ namespace Feature.Common.Parameter
     [CreateAssetMenu(fileName = "SimpleEnemy1Params.asset", menuName = "Params/SimpleEnemy1Params", order = 0)]
     public class SimpleEnemy1Params : EnemyParams
     {
-        [Tooltip("突撃前のdelay"), Header("突撃前のdelay"),]
+        [Tooltip("突撃前のdelay")]
         public float rushBeforeDelay = 0.2f;
 
-        [Tooltip("突撃後のdelay"), Header("突撃後のdelay"),]
+        [Tooltip("突撃後のdelay")]
         public float rushAfterDelay = 0.6f;
 
-        [Tooltip("突進開始距離"), Header("突進開始距離"),] public float rushStartDistance = 7f;
+        [Tooltip("突進開始距離")] public float rushStartDistance = 7f;
 
-        [Tooltip("突進速度"), Header("突進速度"),] public float rushSpeed = 5f;
+        [Tooltip("突進速度")] public float rushSpeed = 5f;
     }
 }

--- a/src/Assets/Scripts/Feature/Common/Parameter/SimpleEnemy2Params.cs
+++ b/src/Assets/Scripts/Feature/Common/Parameter/SimpleEnemy2Params.cs
@@ -10,15 +10,15 @@ namespace Feature.Common.Parameter
     [CreateAssetMenu(fileName = "SimpleEnemy2Params.asset", menuName = "Params/SimpleEnemy2Params", order = 0)]
     public class SimpleEnemy2Params : EnemyParams
     {
-        [Tooltip("射撃距離"), Header("射撃距離"),] public float shootDistance = 15f;
+        [Tooltip("射撃距離")] public float shootDistance = 15f;
 
-        [Tooltip("射撃スピード"), Header("射撃スピード"),] public float shootSpeed = 5f;
+        [Tooltip("射撃スピード")] public float shootSpeed = 5f;
 
-        [Tooltip("射撃間隔"), Header("射撃間隔"),] public float shootIntervalSec = 0.4f;
+        [Tooltip("射撃間隔")] public float shootIntervalSec = 0.4f;
 
-        [Tooltip("１度に打つ数"), Header("１度に打つ数"),] public int shootCount = 3;
+        [Tooltip("１度に打つ数"),] public int shootCount = 3;
 
-        [Tooltip("射撃後の待機時間"), Header("射撃後の待機時間"),]
+        [Tooltip("射撃後の待機時間")]
         public float shootAfterSec = 1f;
     }
 }


### PR DESCRIPTION
既存のパラメータクラスを改善し、パラメータのグループ化とツールチップ表示に対応。

### 確認事項
Editor拡張のため、リリースビルドに影響しないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しいパラメータユーティリティシステムの基盤として、`BaseParameter`クラスを追加しました。
	- Unityエディタ内でのパラメータの表示を改善するために、`SimpleEditor`クラスを導入しました。
	- `ToggleGroupAttribute`を使用して、パラメータのグループ化を可能にしました。

- **変更点**
	- `EnemyParams`および`CharacterParams`クラスが`BaseParameter`から継承するように更新されました。
	- 複数のフィールドで属性が`[Header(...)]`から`[ToggleGroup(...)]`に変更され、Unityエディタでの表示が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->