### PR TITLE
:bug: fix: 弾の生成位置と向き、判定リストの調整

### DIFF
--- a/src/Assets/Scenes/Template/Stage.unity
+++ b/src/Assets/Scenes/Template/Stage.unity
@@ -370,6 +370,101 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 154582531}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &157657038
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 213538022}
+    m_Modifications:
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -25.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7437453453869855136, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: overrideParams
+      value: 
+      objectReference: {fileID: 11400000, guid: 395334fede92840a687d19383be65290,
+        type: 2}
+    - target: {fileID: 7437453453869855136, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: respawnTimeSec
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7437453453869855136, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: spawnEnemyType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7437453453869855136, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: points.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8529875732360637480, guid: a1bb7634d6aec412b97028e350fb9469,
+        type: 3}
+      propertyPath: m_Name
+      value: EnemySpawnPoint (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a1bb7634d6aec412b97028e350fb9469, type: 3}
+--- !u!4 &157657039 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5957117387110517815, guid: a1bb7634d6aec412b97028e350fb9469,
+    type: 3}
+  m_PrefabInstance: {fileID: 157657038}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &185606110
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,6 +602,7 @@ Transform:
   - {fileID: 438578797}
   - {fileID: 1618299819}
   - {fileID: 2006195963}
+  - {fileID: 157657039}
   - {fileID: 326508687}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2378,7 +2474,7 @@ PrefabInstance:
     - target: {fileID: 974588675384877354, guid: 2536c13a70eb64bbdb5c44fa72e0f117,
         type: 3}
       propertyPath: field of view
-      value: 24
+      value: 29.05704
       objectReference: {fileID: 0}
     - target: {fileID: 3606400983697465113, guid: 2536c13a70eb64bbdb5c44fa72e0f117,
         type: 3}
@@ -2433,7 +2529,7 @@ PrefabInstance:
     - target: {fileID: 7271379122264895468, guid: 2536c13a70eb64bbdb5c44fa72e0f117,
         type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 24
+      value: 29.05704
       objectReference: {fileID: 0}
     - target: {fileID: 7729599276646446907, guid: 2536c13a70eb64bbdb5c44fa72e0f117,
         type: 3}

--- a/src/Assets/Scripts/Feature/Component/Enemy/DroneAgent.cs
+++ b/src/Assets/Scripts/Feature/Component/Enemy/DroneAgent.cs
@@ -166,8 +166,12 @@ namespace Feature.Component.Enemy
                 case DroneAttackType.Bullet:
                     for (var _ = 0; _ < enemyParams.shotCount; _++)
                     {
-                        var bullet = ObjectFactory.Instance.CreateObject(enemyParams.bulletPrefab, transform.position,
+                        var toPlayerDirection = (playerTransform.position - transform.position).normalized;
+                        var bullet = ObjectFactory.Instance.CreateObject(
+                            enemyParams.bulletPrefab,
+                            transform.position + toPlayerDirection * 1f,
                             Quaternion.identity);
+                        bullet.transform.LookAt(playerTransform);
                         var bulletRb = bullet.GetComponent<DamagedTrigger>();
                         bulletRb.SetHitObject(false, true, true);
                         bulletRb.ExecuteWithFollow(playerTransform, enemyParams.bulletSpeed, enemyParams.damage,

--- a/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy2Agent.cs
+++ b/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy2Agent.cs
@@ -178,10 +178,13 @@ namespace Feature.Component.Enemy
             var dir = (playerTransform.position - transform.position).normalized;
             for (var _ = 0; _ < enemyParams.shootCount; _++)
             {
-                var bullet = ObjectFactory.Instance.CreateObject(bulletPrefab, transform.position, Quaternion.identity);
+                var bullet = ObjectFactory.Instance.CreateObject(
+                    bulletPrefab,
+                    transform.position + dir * 1f,
+                    Quaternion.identity);
                 bullet.transform.LookAt(playerTransform);
                 var bulletRb = bullet.GetComponent<DamagedTrigger>();
-                bulletRb.SetHitObject(false, true, true);
+                bulletRb.SetHitObject(true, true, true);
                 bulletRb.Execute(dir, enemyParams.shootSpeed, enemyParams.damage, enemyParams.bulletLifeTime);
                 bulletRb.OnHitEvent += () => onHitBullet?.Invoke();
                 yield return Wait(enemyParams.shootIntervalSec);

--- a/src/Assets/Settings/Enemy/BulletDroneParams.asset
+++ b/src/Assets/Settings/Enemy/BulletDroneParams.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   explosionRadius: 5
   explosionDamage: 20
   attackType: 0
-  bulletPrefab: {fileID: 7359196021201563163, guid: d0e23bcee8f76406db28e20292aa6f84,
+  bulletPrefab: {fileID: 7359196021201563163, guid: 052105eff95385244b406d70ebee8e0f,
     type: 3}
   bulletSpeed: 10
   shotCount: 1


### PR DESCRIPTION
弾が表示される位置をプレイヤーに近づけ、プレイヤーを向くように調整しました。

## やった事
<!-- このプルリクエストにて何をしたのか？ -->

## Related Issue
- close #325 

## 動作確認
<!--  
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->

## レビューしてほしいこと
- [ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報 -->
- 
