### PR TITLE
:sparkles: feat: 相対座標importボタンとランダムスポーン機能追加

### DIFF
--- a/src/Assets/Scripts/Core/Utilities/ListEx.cs
+++ b/src/Assets/Scripts/Core/Utilities/ListEx.cs
@@ -11,6 +11,10 @@ namespace Core.Utilities
 
         public static T RandomElement<T>(this List<T> list)
         {
+            if (list.Count == 0)
+            {
+                return default;
+            }
             return list[UnityEngine.Random.Range(0, list.Count)];
         }
     }

--- a/src/Assets/Scripts/Core/Utilities/Parameter/ToggleGroup.cs
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/ToggleGroup.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Core.Utilities.Parameter
 {
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
     public class ToggleGroupAttribute: Attribute
     {
         public string GroupName { get; private set; }

--- a/src/Assets/Scripts/Core/Utilities/Parameter/VectorToggleDrawer.cs
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/VectorToggleDrawer.cs
@@ -1,0 +1,62 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Core.Utilities.Parameter
+{
+
+    [CustomPropertyDrawer(typeof(Vector3))]
+    public class Vector3ToggleDrawer : PropertyDrawer
+    {
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            // スイッチの表示
+            var toggleRect = new Rect(position.x, position.y, 50, EditorGUIUtility.singleLineHeight);
+            var onRelative = GUI.Button(toggleRect, "import");
+
+            var relativeValue = property.vector3Value;
+            if (onRelative)
+            {
+                var referencePosition = GetReferencePosition(property);
+                relativeValue = referencePosition;
+            }
+            var fieldRect = new Rect(position.x + 50, position.y, position.width - 50, EditorGUIUtility.singleLineHeight);
+            relativeValue = EditorGUI.Vector3Field(fieldRect, property.name, relativeValue);
+            property.vector3Value = relativeValue;
+
+            EditorGUI.EndProperty();
+        }
+        
+        
+        /// <summary>
+        /// SerializedProperty から関連するオブジェクトの Transform.position を取得
+        /// </summary>
+        private Vector3 GetReferencePosition(SerializedProperty property)
+        {
+            // 対象オブジェクトの取得
+            var targetObject = property.serializedObject.targetObject;
+
+            if (targetObject is MonoBehaviour monoBehaviour)
+            {
+                // MonoBehaviour の場合、Transform.position を基準座標に設定
+                return monoBehaviour.transform.position;
+            }
+            else if (targetObject is ScriptableObject)
+            {
+                // ScriptableObject の場合、任意の基準値を返す（必要に応じて設定）
+                return Vector3.zero;
+            }
+
+            // それ以外はデフォルト値として Vector3.zero を返す
+            return Vector3.zero;
+        }
+        
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            // トグルスイッチ + Vector3 フィールドの高さを計算
+            return EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+        }
+    }
+}

--- a/src/Assets/Scripts/Core/Utilities/Parameter/VectorToggleDrawer.cs.meta
+++ b/src/Assets/Scripts/Core/Utilities/Parameter/VectorToggleDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c19cd7e479be49ecb3f9b3243189663c
+timeCreated: 1732958809


### PR DESCRIPTION
新しいVector3ToggleDrawerを作成し、スクリプトを拡張してスポーンポイントを可視化・編集可能にしました。リストのランダム選択時に空リスト対応を追加しました。

## やった事
<!-- このプルリクエストにて何をしたのか？ -->
importクリックで座標が入力される
<img width="544" alt="スクリーンショット 2024-11-30 19 04 01" src="https://github.com/user-attachments/assets/1b534c3d-82f8-4ec5-8200-f7eadf07b9c1">

## Related Issue
- close #327 


## レビューしてほしいこと
- [ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報 -->
- 
