### PR TITLE
:bug: fix: レイヤーマスク未設定時のデフォルト処理を追加

### DIFF
--- a/src/Assets/Scripts/Core/Utilities/Rays.cs
+++ b/src/Assets/Scripts/Core/Utilities/Rays.cs
@@ -17,6 +17,10 @@ namespace Core.Utilities
         public static RaycastHit[] GetBoxCastAll(this Transform transform, Vector3 halfExtents, Vector3 direction,
             float maxDistance, int capacity = 5, LayerMask layerMask = default)
         {
+            if (layerMask == default)
+            {
+                layerMask = Physics.DefaultRaycastLayers;
+            }
             var results = new RaycastHit[capacity];
             Physics.BoxCastNonAlloc(transform.position, halfExtents, direction, results, Quaternion.identity,
                 maxDistance, layerMask);


### PR DESCRIPTION
レイヤーマスクが未設定の場合にデフォルト値を使用する処理を追加し、エラーを防止します。これにより、デフォルトレイヤーマスクでのBoxCastが成功します。

## やった事
<!-- このプルリクエストにて何をしたのか？ -->
deleteItemSpawnerが動かなくなっていたことから
## Related Issue
- close #~~

## 動作確認
<!--  
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->

## レビューしてほしいこと
- [ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報 -->
- 
