### PR TITLE
disable kill animation

### DIFF
--- a/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy1Agent.cs
+++ b/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy1Agent.cs
@@ -253,7 +253,8 @@ namespace Feature.Component.Enemy
         
         public void DestroyEnemy()
         {
-            loseAnimation = true;
+           // loseAnimation = true;
+            FlowCancel();
             animator.Play("defeat");
         }
     }

--- a/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy2Agent.cs
+++ b/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy2Agent.cs
@@ -244,7 +244,8 @@ namespace Feature.Component.Enemy
         }
         public void DestroyEnemy()
         {
-            loseAnimation = true;
+            // loseAnimation = true;
+            FlowCancel();
             animator.Play("defeat");
         }
     }

--- a/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy2FlyAgent.cs
+++ b/src/Assets/Scripts/Feature/Component/Enemy/SimpleEnemy2FlyAgent.cs
@@ -41,6 +41,7 @@ namespace Feature.Component.Enemy
         private void Awake()
         {
             rb = GetComponent<Rigidbody>();
+            animator = GetComponentInChildren<Animator>();
             position.Value = transform.position;
         }
 
@@ -254,10 +255,14 @@ namespace Feature.Component.Enemy
 
         public void DestroyEnemy()
         {
-            loseAnimation = true;
+            // loseAnimation = true;
+            FlowCancel();
+            rb.isKinematic = false;
+            rb.useGravity = true;
+            rb.velocity = Vector3.down;
             try
             {
-                animator.Play("defeat");
+               animator.Play("defeat");
             }
             catch (Exception e)
             {

--- a/src/Assets/Scripts/Feature/View/EnemyView.cs
+++ b/src/Assets/Scripts/Feature/View/EnemyView.cs
@@ -4,6 +4,7 @@ using System;
 using Core.Utilities.Health;
 using Feature.Common.Constants;
 using Feature.Interface;
+using UniRx;
 using UnityEngine;
 
 #endregion
@@ -38,16 +39,19 @@ namespace Feature.View
             {
                 CurrentHealth = 0;
                 OnDamageEvent?.Invoke(new DamageResult.Killed(transform), hitPoint);
-                // delete 
-                OnHealth0Event?.Invoke();
                 agent.FlowCancel();
                 agent.DestroyEnemy();
+                OnHealth0Event?.Invoke();
                 agent.Delete();
-                if (gameObject != null)
-                {
-                    Destroy(gameObject, 3f);
-                }
                 OnRemoveEvent?.Invoke();
+                // delete
+                Destroy(gameObject);
+                // Observable
+                //     .Timer(TimeSpan.FromSeconds(3f))
+                //     .Subscribe(_ =>
+                //     {
+                //         Destroy(gameObject);
+                //     });
                 return new DamageResult.Killed(transform);
             }
             else


### PR DESCRIPTION
## やった事
<!-- このプルリクエストにて何をしたのか？ -->
敵が倒された時にunityがクラッシュするようになっていたため、修正までanimationを無効化
## Related Issue
- close #~~

## 動作確認
<!--  
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->

## レビューしてほしいこと
- [ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報 -->
- 
